### PR TITLE
Fix StaticAllocation.toCode serialization

### DIFF
--- a/src/engine/models/Bill/DepositRecord/StaticAllocation.ts
+++ b/src/engine/models/Bill/DepositRecord/StaticAllocation.ts
@@ -108,6 +108,6 @@ export class StaticAllocation {
   }
 
   toCode() {
-    return `new StaticAllocation(${this.json})`;  
+    return `new StaticAllocation(${JSON.stringify(this.json)})`;
   }
 }

--- a/src/engine/tests/models/staticAllocation.test.ts
+++ b/src/engine/tests/models/staticAllocation.test.ts
@@ -1,0 +1,13 @@
+import { StaticAllocation } from "../../models/Bill/DepositRecord/StaticAllocation";
+
+describe('StaticAllocation.toCode', () => {
+  it('should serialize to executable code string', () => {
+    const alloc = new StaticAllocation({
+      principal: 100,
+      interest: 50,
+      fees: 25,
+      prepayment: 0,
+    });
+    expect(alloc.toCode()).toBe('new StaticAllocation({"principal":100,"interest":50,"fees":25,"prepayment":0})');
+  });
+});


### PR DESCRIPTION
## Summary
- fix StaticAllocation.toCode to properly serialize properties
- add unit test for StaticAllocation.toCode

## Testing
- `npm test` *(fails: jest not found)*