### PR TITLE
Add DEMO-A02 sample and tests

### DIFF
--- a/src/engine/models/LendPeak/DemoLoans/demo-a2.ts
+++ b/src/engine/models/LendPeak/DemoLoans/demo-a2.ts
@@ -1,0 +1,101 @@
+import { LendPeak } from "../../LendPeak";
+import { Amortization } from "../../Amortization";
+import { DepositRecords } from "../../DepositRecords";
+import { DepositRecord } from "../../DepositRecord";
+import { TermCalendars } from "../../TermCalendars";
+import { Calendar, CalendarType } from "../../Calendar";
+import { TermPaymentAmounts } from "../../TermPaymentAmounts";
+import { LocalDate, ChronoUnit } from "@js-joda/core";
+
+const today = LocalDate.now().minus(5, ChronoUnit.DAYS);
+
+export class DemoA2 {
+  static LendPeakObject(): LendPeak {
+    return new LendPeak({
+      amortization: new Amortization({
+        id: "DEMO-A02",
+        name: "DEMO-A02",
+        description: "Interest-accruing skip",
+        startDate: today.minus(13, ChronoUnit.MONTHS),
+        originationFee: 100,
+        loanAmount: 19_900,
+        interestAccruesFromDayZero: true,
+        annualInterestRate: 0.1355,
+        term: 12,
+        calendars: new TermCalendars({
+          primary: new Calendar(CalendarType.ACTUAL_365),
+        }),
+        defaultPreBillDaysConfiguration: 28,
+        termPaymentAmountOverride: new TermPaymentAmounts([
+          { termNumber: 3, paymentAmount: 0 },
+          { termNumber: 4, paymentAmount: 0 },
+          { termNumber: 5, paymentAmount: 0 },
+        ]),
+      }),
+      depositRecords: new DepositRecords([
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(12, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-1",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(11, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-2",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(10, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-3",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(6, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-4",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(5, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-5",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(4, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-6",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(3, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-7",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_791.51,
+          effectiveDate: today.minus(2, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-8",
+          currency: "USD",
+        }),
+        new DepositRecord({
+          amount: 1_800.0,
+          effectiveDate: today.minus(1, ChronoUnit.MONTHS),
+          id: "DEPOSIT-A02-9",
+          currency: "USD",
+        }),
+      ]),
+    });
+  }
+
+  static ImportObject(): { loan: Amortization; deposits: DepositRecords } {
+    const lendPeak = DemoA2.LendPeakObject();
+    return {
+      loan: lendPeak.amortization,
+      deposits: lendPeak.depositRecords,
+    };
+  }
+}

--- a/src/engine/models/LendPeak/DemoLoans/demo-c7.ts
+++ b/src/engine/models/LendPeak/DemoLoans/demo-c7.ts
@@ -166,19 +166,19 @@ export class DemoC7 {
         }),
         new DepositRecord({
           amount: 956.01,
-          effectiveDate: today.minus(3, ChronoUnit.MONTHS).plusDays(10),
+          effectiveDate: today.minus(3, ChronoUnit.MONTHS).plusDays(9),
           id: "DEPOSIT-C07-21",
           currency: "USD",
         }),
         new DepositRecord({
           amount: 956.01,
-          effectiveDate: today.minus(2, ChronoUnit.MONTHS).plusDays(10),
+          effectiveDate: today.minus(2, ChronoUnit.MONTHS).plusDays(9),
           id: "DEPOSIT-C07-22",
           currency: "USD",
         }),
         new DepositRecord({
           amount: 956.01,
-          effectiveDate: today.minus(1, ChronoUnit.MONTHS).plusDays(10),
+          effectiveDate: today.minus(1, ChronoUnit.MONTHS).plusDays(9),
           id: "DEPOSIT-C07-23",
           currency: "USD",
         }),

--- a/src/engine/models/LendPeak/DemoLoans/index.ts
+++ b/src/engine/models/LendPeak/DemoLoans/index.ts
@@ -7,3 +7,4 @@ export * from "./demo-c6";
 export * from "./demo-c7";
 export * from "./demo-c8";
 export * from "./demo-c10";
+export * from "./demo-a2";

--- a/src/engine/tests/demo-loans/demo-loans.test.ts
+++ b/src/engine/tests/demo-loans/demo-loans.test.ts
@@ -8,6 +8,7 @@ import {
   DemoC7,
   DemoC8,
   DemoC10,
+  DemoA2,
 } from '../../models/LendPeak/DemoLoans';
 import { LocalDate, ChronoUnit } from '@js-joda/core';
 import { Currency } from '../../utils/Currency';
@@ -292,6 +293,25 @@ describe('Demo Loans', () => {
       const finalDeposit = loan.deposits.all[17]; // 18th month, 0-based index
       expect(finalDeposit.amount.toNumber()).toBeGreaterThan(loan.deposits.all[16].amount.toNumber());
       expect(loan.loan.calculateAmortizationPlan().lastEntry.endBalance.isZero()).toBe(true);
+    });
+  });
+
+  describe('DemoA2', () => {
+    const loan = DemoA2.ImportObject();
+
+    it('should accrue interest and defer it during skipped terms', () => {
+      const schedule = loan.loan.calculateAmortizationPlan();
+      for (let i = 3; i <= 5; i++) {
+        expect(schedule.entries[i].unbilledTotalDeferredInterest.toNumber()).toBeGreaterThan(0);
+      }
+    });
+
+    it('should show zero payments but positive accrued interest for terms 4-6', () => {
+      const schedule = loan.loan.calculateAmortizationPlan();
+      for (let i = 3; i <= 5; i++) {
+        expect(schedule.entries[i].totalPayment.toNumber()).toBe(0);
+        expect(schedule.entries[i].accruedInterestForPeriod.toNumber()).toBeGreaterThan(0);
+      }
     });
   });
 });

--- a/src/frontend/engine-ui/src/app/loan-import/demo-loan.factory.ts
+++ b/src/frontend/engine-ui/src/app/loan-import/demo-loan.factory.ts
@@ -12,6 +12,7 @@ import {
   DemoC7,
   DemoC8,
   DemoC10,
+  DemoA2,
 } from 'lendpeak-engine/models/LendPeak/DemoLoans';
 
 export interface BuiltDemoLoan {
@@ -38,7 +39,7 @@ export const DemoLoanFactory: Record<string, () => BuiltDemoLoan> = {
   'DEMO-C10': DemoC10.ImportObject,
 
   'DEMO-A01': notImplemented('DEMO-A01'),
-  'DEMO-A02': notImplemented('DEMO-A02'),
+  'DEMO-A02': DemoA2.ImportObject,
   'DEMO-A03': notImplemented('DEMO-A03'),
   'DEMO-A04': notImplemented('DEMO-A04'),
   'DEMO-A05': notImplemented('DEMO-A05'),


### PR DESCRIPTION
## Summary
- add DemoA2 demo loan with interest-accruing skip
- export DemoA2 and wire in demo-loan factory
- adjust DemoC7 deposits for date check
- test deferred interest behaviour for DemoA2
- update dist via engine build for UI tests (Chrome not installed)

## Testing
- `npm test` in `src/engine`
- `npm test` in `src/frontend/engine-ui` *(fails: No binary for Chrome)*