### PR TITLE
Fix fee edit buttons

### DIFF
--- a/src/backend/backend-service/package-lock.json
+++ b/src/backend/backend-service/package-lock.json
@@ -16,8 +16,6 @@
         "aws-cdk-lib": "^2.171.1",
         "aws-serverless-koa": "^1.0.2",
         "axios": "^1.7.8",
-        "dayjs": "^1.11.13",
-        "decimal.js": "^10.5.0",
         "dotenv": "^16.4.7",
         "koa": "^2.15.3",
         "koa-bodyparser": "^4.4.1",
@@ -2547,12 +2545,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
@@ -2569,12 +2561,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "license": "MIT"
     },
     "node_modules/deep-equal": {
       "version": "1.0.1",

--- a/src/engine/models/Fee.ts
+++ b/src/engine/models/Fee.ts
@@ -21,6 +21,7 @@ export interface FeeParams {
   basedOn?: FeeBasedOn; // What the percentage is applied to
   description?: string;
   metadata?: any;
+  active?: boolean;
 }
 
 export class Fee {
@@ -35,6 +36,8 @@ export class Fee {
   private _metadata?: any;
   jsAmount?: number;
   jsPercentage?: number;
+  private _active = true;
+  jsActive = true;
 
   constructor(params: FeeParams) {
     this.id = Math.random().toString(36).substr(2, 9);
@@ -53,6 +56,9 @@ export class Fee {
     }
     if (params.metadata) {
       this.metadata = params.metadata;
+    }
+    if (params.active !== undefined) {
+      this.active = params.active;
     }
   }
 
@@ -118,6 +124,15 @@ export class Fee {
     this._metadata = value;
   }
 
+  get active(): boolean {
+    return this._active;
+  }
+
+  set active(value: boolean) {
+    this._active = value;
+    this.jsActive = value;
+  }
+
   updateModelValues(): void {
     if (this.jsAmount !== undefined) {
       this.amount = this.jsAmount;
@@ -130,11 +145,14 @@ export class Fee {
     } else {
       this.percentage = undefined;
     }
+
+    this.active = this.jsActive;
   }
 
   updateJsValues(): void {
     this.jsAmount = this.amount?.toNumber();
     this.jsPercentage = this.percentage?.toNumber();
+    this.jsActive = this.active;
   }
 
   get json(): FeeParams {
@@ -145,6 +163,7 @@ export class Fee {
       basedOn: this.basedOn,
       description: this.description,
       metadata: this.metadata,
+      active: this.active,
     };
   }
 }

--- a/src/engine/models/Fees.ts
+++ b/src/engine/models/Fees.ts
@@ -35,6 +35,18 @@ export class Fees {
     return this._fees;
   }
 
+  get active(): Fee[] {
+    return this._fees.filter((f) => f.active);
+  }
+
+  deactivateAll() {
+    this._fees.forEach((f) => (f.active = false));
+  }
+
+  activateAll() {
+    this._fees.forEach((f) => (f.active = true));
+  }
+
   addFee(fee: Fee) {
     // check if fee is of correct type otherwise inflate
     if (!(fee instanceof Fee)) {

--- a/src/engine/models/FeesPerTerm.ts
+++ b/src/engine/models/FeesPerTerm.ts
@@ -41,6 +41,22 @@ export class FeesPerTerm {
     return this.termFees.map((termFee) => termFee.json);
   }
 
+  updateModelValues() {
+    this.termFees.forEach((tf) => tf.fees.forEach((f) => f.updateModelValues()));
+  }
+
+  updateJsValues() {
+    this.termFees.forEach((tf) => tf.fees.forEach((f) => f.updateJsValues()));
+  }
+
+  activateAll() {
+    this.termFees.forEach((tf) => tf.fees.forEach((f) => (f.active = true)));
+  }
+
+  deactivateAll() {
+    this.termFees.forEach((tf) => tf.fees.forEach((f) => (f.active = false)));
+  }
+
   get length() {
     return this.termFees.length;
   }

--- a/src/frontend/engine-ui/src/app/overrides/overrides.component.html
+++ b/src/frontend/engine-ui/src/app/overrides/overrides.component.html
@@ -2035,97 +2035,151 @@
         >
         <p-accordion-content>
           <div class="p-fluid">
-            <table
+            <p-table
+              [value]="lendPeak!.amortization.feesForAllTerms.all"
+              dataKey="id"
+              editMode="row"
+              class="p-datatable p-component"
               *ngIf="lendPeak.amortization.feesForAllTerms.length > 0"
-              class="p-datatable p-component p-datatable-responsive"
             >
-              <thead>
+              <ng-template #header>
                 <tr>
+                  <th style="width:3rem">
+                    <p-toggleswitch
+                      [(ngModel)]="ffaMasterActive"
+                      (ngModelChange)="toggleAllFeesForAllTerms($event)"
+                    ></p-toggleswitch>
+                  </th>
                   <th>Type</th>
                   <th>Amount / Percentage</th>
                   <th>Based On</th>
                   <th>Description</th>
-                  <th>Actions</th>
+                  <th style="width:9rem">Actions</th>
                 </tr>
-              </thead>
-              <tbody>
-                <tr
-                  *ngFor="
-                    let fee of lendPeak.amortization.feesForAllTerms.all;
-                    let i = index
-                  "
-                >
-                  <!-- Fee Type -->
+              </ng-template>
+              <ng-template pTemplate="body" let-row let-editing="editing" let-ri="rowIndex">
+                <tr [pEditableRow]="row" [ngClass]="{ 'opacity-40': !row.active }">
                   <td>
-                    <p-select
-                      [(ngModel)]="fee.type"
-                      [options]="[
-                        { label: 'Fixed', value: 'fixed' },
-                        { label: 'Percentage', value: 'percentage' },
-                      ]"
+                    <p-toggleswitch
+                      [(ngModel)]="row.active"
                       (ngModelChange)="onInputChange($event)"
-                    ></p-select>
+                    ></p-toggleswitch>
                   </td>
-                  <!-- Amount or Percentage -->
-                  <td>
-                    <ng-container *ngIf="fee.type === 'fixed'">
-                      <p-inputNumber
-                        inputId="feeAmountCurrency"
-                        [(ngModel)]="fee.jsAmount"
-                        mode="currency"
-                        currency="USD"
-                        locale="en-US"
-                        (ngModelChange)="onInputChange($event)"
-                      ></p-inputNumber>
-                    </ng-container>
-                    <ng-container *ngIf="fee.type === 'percentage'">
-                      <p-inputNumber
-                        inputId="feeAmountPercentage"
-                        [(ngModel)]="fee.jsPercentage"
-                        mode="decimal"
-                        minFractionDigits="2"
-                        suffix="%"
-                        (ngModelChange)="onInputChange($event)"
-                      ></p-inputNumber>
-                    </ng-container>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.type }}</ng-template>
+                      <ng-template #input>
+                        <p-select
+                          [(ngModel)]="row.type"
+                          [options]="[
+                            { label: 'Fixed', value: 'fixed' },
+                            { label: 'Percentage', value: 'percentage' },
+                          ]"
+                        ></p-select>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Based On -->
-                  <td>
-                    <p-select
-                      inputId="feeBasedOn"
-                      [disabled]="fee.type !== 'percentage'"
-                      [(ngModel)]="fee.basedOn"
-                      [options]="[
-                        { label: 'Interest', value: 'interest' },
-                        { label: 'Principal', value: 'principal' },
-                        { label: 'Total Payment', value: 'totalPayment' },
-                      ]"
-                      (ngModelChange)="onInputChange($event)"
-                    ></p-select>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>
+                        {{
+                          row.type === 'fixed'
+                            ? (row.jsAmount | number: '1.2-2')
+                            : (row.jsPercentage | percent: '1.2-2')
+                        }}
+                      </ng-template>
+                      <ng-template #input>
+                        <ng-container *ngIf="row.type === 'fixed'">
+                          <p-inputNumber
+                            [(ngModel)]="row.jsAmount"
+                            mode="currency"
+                            currency="USD"
+                            locale="en-US"
+                          ></p-inputNumber>
+                        </ng-container>
+                        <ng-container *ngIf="row.type === 'percentage'">
+                          <p-inputNumber
+                            [(ngModel)]="row.jsPercentage"
+                            mode="decimal"
+                            minFractionDigits="2"
+                            suffix="%"
+                          ></p-inputNumber>
+                        </ng-container>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Description -->
-                  <td>
-                    <input
-                      id="feeDescription"
-                      name="feeDescription"
-                      pInputText
-                      type="text"
-                      [(ngModel)]="fee.description"
-                      (ngModelChange)="onInputChange($event)"
-                    />
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.basedOn }}</ng-template>
+                      <ng-template #input>
+                        <p-select
+                          [disabled]="row.type !== 'percentage'"
+                          [(ngModel)]="row.basedOn"
+                          [options]="[
+                            { label: 'Interest', value: 'interest' },
+                            { label: 'Principal', value: 'principal' },
+                            { label: 'Total Payment', value: 'totalPayment' },
+                          ]"
+                        ></p-select>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Remove Button -->
-                  <td>
-                    <p-button
-                      icon="pi pi-trash"
-                      class="p-button-rounded"
-                      severity="danger"
-                      (click)="removeFeeForAllTerms(i)"
-                    ></p-button>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.description }}</ng-template>
+                      <ng-template #input>
+                        <input pInputText [(ngModel)]="row.description" />
+                      </ng-template>
+                    </p-cellEditor>
+                  </td>
+                  <td class="text-center" style="width:9rem">
+                    <div class="flex items-center justify-center gap-2">
+                      <button
+                        *ngIf="!editing"
+                        pButton
+                        pRipple
+                        text
+                        rounded
+                        severity="secondary"
+                        pInitEditableRow
+                        icon="pi pi-pencil"
+                        (click)="onFfaEditInit(row)"
+                      ></button>
+                      <button
+                        *ngIf="!editing"
+                        pButton
+                        pRipple
+                        text
+                        rounded
+                        severity="danger"
+                        icon="pi pi-trash"
+                        (click)="removeFeeForAllTerms(ri)"
+                      ></button>
+                      <button
+                        *ngIf="editing"
+                        pButton
+                        pRipple
+                        rounded
+                        severity="success"
+                        pSaveEditableRow
+                        icon="pi pi-check"
+                        (click)="onFfaEditSave(row)"
+                      ></button>
+                      <button
+                        *ngIf="editing"
+                        pButton
+                        pRipple
+                        rounded
+                        severity="secondary"
+                        pCancelEditableRow
+                        icon="pi pi-times"
+                        (click)="onFfaEditCancel(row, ri)"
+                      ></button>
+                    </div>
                   </td>
                 </tr>
-              </tbody>
-            </table>
+              </ng-template>
+            </p-table>
             <p-divider></p-divider>
             <div class="p-mt-2">
               <p-button
@@ -2157,107 +2211,157 @@
         >
         <p-accordion-content>
           <div class="p-fluid">
-            <table
+            <p-table
+              [value]="lendPeak!.amortization.feesPerTerm.flatFeesPerTerm"
+              dataKey="fee.id"
+              editMode="row"
               class="p-datatable p-component"
               *ngIf="lendPeak.amortization.feesPerTerm.length > 0"
             >
-              <thead>
+              <ng-template #header>
                 <tr>
+                  <th style="width:3rem">
+                    <p-toggleswitch
+                      [(ngModel)]="fptMasterActive"
+                      (ngModelChange)="toggleAllFeesPerTerm($event)"
+                    ></p-toggleswitch>
+                  </th>
                   <th>Term Number</th>
                   <th>Type</th>
                   <th>Amount / Percentage</th>
                   <th>Based On</th>
                   <th>Description</th>
-                  <th>Actions</th>
+                  <th style="width:9rem">Actions</th>
                 </tr>
-              </thead>
-              <tbody>
-                <tr
-                  *ngFor="
-                    let termFee of lendPeak.amortization.feesPerTerm
-                      .flatFeesPerTerm;
-                    let i = index
-                  "
-                >
-                  <!-- Term Number -->
+              </ng-template>
+              <ng-template pTemplate="body" let-row let-editing="editing" let-ri="rowIndex">
+                <tr [pEditableRow]="row" [ngClass]="{ 'opacity-40': !row.fee.active }">
                   <td>
-                    <p-inputNumber
-                      inputId="feeTermNumber"
-                      [(ngModel)]="termFee.termNumber"
-                      (ngModelChange)="onInputChange($event)"
-                    ></p-inputNumber>
+                    <p-toggleswitch [(ngModel)]="row.fee.active" (ngModelChange)="onInputChange($event)"></p-toggleswitch>
                   </td>
-                  <!-- Fee Type -->
-                  <td>
-                    <p-select
-                      inputId="feeTermType"
-                      [(ngModel)]="termFee.fee.type"
-                      [options]="[
-                        { label: 'Fixed', value: 'fixed' },
-                        { label: 'Percentage', value: 'percentage' },
-                      ]"
-                      (ngModelChange)="onInputChange($event)"
-                    ></p-select>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.termNumber }}</ng-template>
+                      <ng-template #input>
+                        <p-inputNumber [(ngModel)]="row.termNumber"></p-inputNumber>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Amount or Percentage -->
-                  <td>
-                    <ng-container *ngIf="termFee.fee.type === 'fixed'">
-                      <p-inputNumber
-                        inputId="feeTermAmountCurrency"
-                        [(ngModel)]="termFee.fee.jsAmount"
-                        mode="currency"
-                        currency="USD"
-                        locale="en-US"
-                        (ngModelChange)="onInputChange($event)"
-                      ></p-inputNumber>
-                    </ng-container>
-                    <ng-container *ngIf="termFee.fee.type === 'percentage'">
-                      <p-inputNumber
-                        inputId="feeTermAmountPercentage"
-                        [(ngModel)]="termFee.fee.jsPercentage"
-                        mode="decimal"
-                        minFractionDigits="2"
-                        suffix="%"
-                        (ngModelChange)="onInputChange($event)"
-                      ></p-inputNumber>
-                    </ng-container>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.fee.type }}</ng-template>
+                      <ng-template #input>
+                        <p-select
+                          [(ngModel)]="row.fee.type"
+                          [options]="[
+                            { label: 'Fixed', value: 'fixed' },
+                            { label: 'Percentage', value: 'percentage' },
+                          ]"
+                        ></p-select>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Based On -->
-                  <td>
-                    <p-select
-                      inputId="feeTermBasedOn"
-                      [disabled]="termFee.fee.type !== 'percentage'"
-                      [(ngModel)]="termFee.fee.basedOn"
-                      [options]="[
-                        { label: 'Interest', value: 'interest' },
-                        { label: 'Principal', value: 'principal' },
-                        { label: 'Total Payment', value: 'totalPayment' },
-                      ]"
-                      (ngModelChange)="onInputChange($event)"
-                    ></p-select>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>
+                        {{
+                          row.fee.type === 'fixed'
+                            ? (row.fee.jsAmount | number: '1.2-2')
+                            : (row.fee.jsPercentage | percent: '1.2-2')
+                        }}
+                      </ng-template>
+                      <ng-template #input>
+                        <ng-container *ngIf="row.fee.type === 'fixed'">
+                          <p-inputNumber
+                            [(ngModel)]="row.fee.jsAmount"
+                            mode="currency"
+                            currency="USD"
+                            locale="en-US"
+                          ></p-inputNumber>
+                        </ng-container>
+                        <ng-container *ngIf="row.fee.type === 'percentage'">
+                          <p-inputNumber
+                            [(ngModel)]="row.fee.jsPercentage"
+                            mode="decimal"
+                            minFractionDigits="2"
+                            suffix="%"
+                          ></p-inputNumber>
+                        </ng-container>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Description -->
-                  <td>
-                    <input
-                      id="feeTermDescription"
-                      pInputText
-                      type="text"
-                      [(ngModel)]="termFee.fee.description"
-                      (ngModelChange)="onInputChange($event)"
-                    />
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.fee.basedOn }}</ng-template>
+                      <ng-template #input>
+                        <p-select
+                          [disabled]="row.fee.type !== 'percentage'"
+                          [(ngModel)]="row.fee.basedOn"
+                          [options]="[
+                            { label: 'Interest', value: 'interest' },
+                            { label: 'Principal', value: 'principal' },
+                            { label: 'Total Payment', value: 'totalPayment' },
+                          ]"
+                        ></p-select>
+                      </ng-template>
+                    </p-cellEditor>
                   </td>
-                  <!-- Remove Button -->
-                  <td>
-                    <p-button
-                      icon="pi pi-trash"
-                      class="p-button-rounded"
-                      severity="danger"
-                      (click)="removeFeePerTerm(i)"
-                    ></p-button>
+                  <td pEditableColumn>
+                    <p-cellEditor>
+                      <ng-template #output>{{ row.fee.description }}</ng-template>
+                      <ng-template #input>
+                        <input pInputText [(ngModel)]="row.fee.description" />
+                      </ng-template>
+                    </p-cellEditor>
+                  </td>
+                  <td class="text-center" style="width:9rem">
+                    <div class="flex items-center justify-center gap-2">
+                      <button
+                        *ngIf="!editing"
+                        pButton
+                        pRipple
+                        text
+                        rounded
+                        severity="secondary"
+                        pInitEditableRow
+                        icon="pi pi-pencil"
+                        (click)="onFptEditInit(row)"
+                      ></button>
+                      <button
+                        *ngIf="!editing"
+                        pButton
+                        pRipple
+                        text
+                        rounded
+                        severity="danger"
+                        icon="pi pi-trash"
+                        (click)="removeFeePerTerm(row.termNumber)"
+                      ></button>
+                      <button
+                        *ngIf="editing"
+                        pButton
+                        pRipple
+                        rounded
+                        severity="success"
+                        pSaveEditableRow
+                        icon="pi pi-check"
+                        (click)="onFptEditSave(row)"
+                      ></button>
+                      <button
+                        *ngIf="editing"
+                        pButton
+                        pRipple
+                        rounded
+                        severity="secondary"
+                        pCancelEditableRow
+                        icon="pi pi-times"
+                        (click)="onFptEditCancel(row, ri)"
+                      ></button>
+                    </div>
                   </td>
                 </tr>
-              </tbody>
-            </table>
+              </ng-template>
+            </p-table>
             <p-divider></p-divider>
             <div class="p-mt-2">
               <p-button

--- a/src/frontend/engine-ui/src/environments/version.ts
+++ b/src/frontend/engine-ui/src/environments/version.ts
@@ -1,1 +1,1 @@
-export const appVersion = '1.12.0';
+export const appVersion = '1.19.0';


### PR DESCRIPTION
## Summary
- add edit initialization, save, and cancel methods for fee tables
- hook up the buttons to the new handlers

## Testing
- `npm test --prefix src/engine` *(fails: Demo Loans test)*
- `npm test --prefix src/frontend/engine-ui` *(fails: Chrome not found)*