### PR TITLE
Fix actual term computation and schedule update

### DIFF
--- a/src/engine/models/LendPeak.ts
+++ b/src/engine/models/LendPeak.ts
@@ -823,6 +823,7 @@ export class LendPeak {
           hasCustomPreBillDays: this.amortization.hasCustomPreBillDays,
           hasCustomBillDueDays: this.amortization.hasCustomBillDueDays,
           hasTermPaymentAmountOverride: this.amortization.termPaymentAmountOverride.length > 0,
+          hasTermExtensions: this.amortization.termExtensions.length > 0,
           hasChangePaymentDates: this.amortization.changePaymentDates.length,
           hasTermInterestAmountOverride: this.amortization.termInterestAmountOverride.length > 0,
           hasTermInterestRateOverride: this.amortization.termInterestRateOverride.length > 0,

--- a/src/engine/models/LendPeak/DemoLoans/README.md
+++ b/src/engine/models/LendPeak/DemoLoans/README.md
@@ -29,6 +29,7 @@
 | **DEMO-A08** | Re-amort after principal mod     | `mods`, `payments`                          | Balance drop triggers schedule rebuild  |
 | **DEMO-A09** | Aggressive over-pay payoff       | `over-payments`, `early-payoff`, `payments` | Escalating extras → payoff month 9      |
 | **DEMO-A10** | Auto-close waiver (< threshold)  | `auto-close`, `early-payoff`, `edge`        | Tolerance triggers synthetic waiver row |
+| **DEMO-A11** | Hardship with term extension     | `mods`, `payments`          | Skip with added term                     |
 
 ---
 

--- a/src/engine/models/LendPeak/DemoLoans/demo-a11.ts
+++ b/src/engine/models/LendPeak/DemoLoans/demo-a11.ts
@@ -1,0 +1,51 @@
+import { LendPeak } from '../../LendPeak';
+import { Amortization } from '../../Amortization';
+import { DepositRecords } from '../../DepositRecords';
+import { TermCalendars } from '../../TermCalendars';
+import { Calendar, CalendarType } from '../../Calendar';
+import { TermPaymentAmounts } from '../../TermPaymentAmounts';
+import { TermPaymentAmount } from '../../TermPaymentAmount';
+import { TermExtensions } from '../../TermExtensions';
+import { TermExtension } from '../../TermExtension';
+import { LocalDate, ChronoUnit } from '@js-joda/core';
+
+const today = LocalDate.now().minus(5, ChronoUnit.DAYS);
+
+export class DemoA11 {
+  static LendPeakObject(): LendPeak {
+    return new LendPeak({
+      amortization: new Amortization({
+        id: 'DEMO-A11',
+        name: 'DEMO-A11',
+        description: 'Hardship with term extension',
+        startDate: today.minus(24, ChronoUnit.MONTHS),
+        originationFee: 100,
+        loanAmount: 19_900,
+        interestAccruesFromDayZero: true,
+        annualInterestRate: 0.1355,
+        term: 24,
+        calendars: new TermCalendars({
+          primary: new Calendar(CalendarType.ACTUAL_365),
+        }),
+        defaultPreBillDaysConfiguration: 28,
+        termPaymentAmountOverride: new TermPaymentAmounts([
+          new TermPaymentAmount({ termNumber: 4, paymentAmount: 0 }),
+          new TermPaymentAmount({ termNumber: 5, paymentAmount: 0 }),
+          new TermPaymentAmount({ termNumber: 6, paymentAmount: 0 }),
+        ]),
+        termExtensions: new TermExtensions([
+          new TermExtension({ termChange: 1 }),
+        ]),
+      }),
+      depositRecords: new DepositRecords([]),
+    });
+  }
+
+  static ImportObject(): { loan: Amortization; deposits: DepositRecords } {
+    const lendPeak = DemoA11.LendPeakObject();
+    return {
+      loan: lendPeak.amortization,
+      deposits: lendPeak.depositRecords,
+    };
+  }
+}

--- a/src/engine/models/LendPeak/DemoLoans/index.ts
+++ b/src/engine/models/LendPeak/DemoLoans/index.ts
@@ -18,3 +18,4 @@ export * from "./demo-a7";
 export * from "./demo-a8";
 export * from "./demo-a9";
 export * from "./demo-a10";
+export * from "./demo-a11";

--- a/src/engine/models/TermExtension.ts
+++ b/src/engine/models/TermExtension.ts
@@ -1,0 +1,73 @@
+import { LocalDate } from '@js-joda/core';
+import { DateUtil } from '../utils/DateUtil';
+
+export interface TermExtensionParams {
+  termChange: number;
+  date?: LocalDate | Date | string;
+  active?: boolean;
+}
+
+export class TermExtension {
+  private _termChange!: number;
+  jsTermChange!: number;
+
+  private _date!: LocalDate;
+  jsDate!: Date;
+
+  private _active = true;
+  jsActive = true;
+
+  constructor(params: TermExtensionParams) {
+    this.termChange = params.termChange;
+    this.date = params.date ?? LocalDate.now();
+    if (params.active !== undefined) this.active = params.active;
+  }
+
+  get termChange(): number {
+    return this._termChange;
+  }
+  set termChange(v: number) {
+    this._termChange = v;
+    this.jsTermChange = v;
+  }
+
+  get date(): LocalDate {
+    return this._date;
+  }
+  set date(v: LocalDate | Date | string) {
+    this._date = DateUtil.normalizeDate(v);
+    this.jsDate = DateUtil.normalizeDateToJsDate(this._date);
+  }
+
+  get active(): boolean {
+    return this._active;
+  }
+  set active(v: boolean) {
+    this._active = v;
+    this.jsActive = v;
+  }
+
+  updateModelValues(): void {
+    this.termChange = this.jsTermChange;
+    this.date = this.jsDate;
+    this.active = this.jsActive;
+  }
+
+  updateJsValues(): void {
+    this.jsTermChange = this.termChange;
+    this.jsDate = DateUtil.normalizeDateToJsDate(this.date);
+    this.jsActive = this.active;
+  }
+
+  get json(): TermExtensionParams {
+    return {
+      termChange: this.termChange,
+      date: this.date.toString(),
+      active: this.active,
+    };
+  }
+
+  toJSON() {
+    return this.json;
+  }
+}

--- a/src/engine/models/TermExtensions.ts
+++ b/src/engine/models/TermExtensions.ts
@@ -1,0 +1,90 @@
+import { TermExtension, TermExtensionParams } from './TermExtension';
+
+export class TermExtensions {
+  private _extensions: TermExtension[] = [];
+  private _modified = false;
+
+  constructor(exts: (TermExtension | TermExtensionParams)[] = []) {
+    this.extensions = exts as any;
+  }
+
+  get modified(): boolean {
+    return this._modified || this._extensions.some((e) => e.jsActive !== undefined);
+  }
+  set modified(v: boolean) {
+    this._modified = v;
+  }
+
+  get extensions(): TermExtension[] {
+    return this._extensions;
+  }
+  set extensions(vals: (TermExtension | TermExtensionParams)[]) {
+    this._extensions = vals.map((v) =>
+      v instanceof TermExtension ? v : new TermExtension(v)
+    );
+    this._modified = true;
+  }
+
+  get all(): TermExtension[] {
+    return this._extensions;
+  }
+
+  get active(): TermExtension[] {
+    return this._extensions.filter((e) => e.active);
+  }
+
+  activateAll() {
+    this._extensions.forEach((e) => (e.active = true));
+  }
+
+  deactivateAll() {
+    this._extensions.forEach((e) => (e.active = false));
+  }
+
+  addExtension(ext: TermExtension) {
+    this._extensions.push(ext);
+    this._modified = true;
+  }
+
+  removeExtension(ext: TermExtension) {
+    this._extensions = this._extensions.filter((e) => e !== ext);
+    this._modified = true;
+  }
+
+  removeExtensionAtIndex(idx: number) {
+    this._extensions.splice(idx, 1);
+    this._modified = true;
+  }
+
+  get length(): number {
+    return this._extensions.length;
+  }
+
+  atIndex(i: number): TermExtension {
+    return this._extensions[i];
+  }
+
+  get first(): TermExtension {
+    return this._extensions[0];
+  }
+
+  get last(): TermExtension {
+    return this._extensions[this._extensions.length - 1];
+  }
+
+  updateModelValues() {
+    this._extensions.forEach((e) => e.updateModelValues());
+  }
+
+  updateJsValues() {
+    this._extensions.forEach((e) => e.updateJsValues());
+  }
+
+  get json() {
+    return this._extensions.map((e) => e.json);
+  }
+
+  toJSON() {
+    return this.json;
+  }
+}

--- a/src/engine/tests/demo-loans/demo-loans.test.ts
+++ b/src/engine/tests/demo-loans/demo-loans.test.ts
@@ -18,6 +18,7 @@ import {
   DemoA8,
   DemoA9,
   DemoA10,
+  DemoA11,
 } from '../../models/LendPeak/DemoLoans';
 import { LocalDate, ChronoUnit } from '@js-joda/core';
 import { Currency } from '../../utils/Currency';
@@ -410,6 +411,16 @@ describe('DemoA10', () => {
   const loan = DemoA10.ImportObject();
   it('should have id DEMO-A10', () => {
     expect(loan.loan.id).toBe('DEMO-A10');
+  });
+});
+
+describe('DemoA11', () => {
+  const loan = DemoA11.ImportObject();
+  it('should have id DEMO-A11', () => {
+    expect(loan.loan.id).toBe('DEMO-A11');
+  });
+  it('should report actual term greater than contractual term', () => {
+    expect(loan.loan.actualTerm).toBeGreaterThan(loan.loan.term);
   });
 });
 });

--- a/src/engine/tests/models/amortization.test.ts
+++ b/src/engine/tests/models/amortization.test.ts
@@ -5,6 +5,8 @@ import { ChangePaymentDate } from "@models/ChangePaymentDate";
 import { ChangePaymentDates } from "@models/ChangePaymentDates";
 import { CalendarType } from "@models/Calendar";
 import { TermCalendars } from "@models/TermCalendars";
+import { TermExtensions } from "@models/TermExtensions";
+import { TermExtension } from "@models/TermExtension";
 import Decimal from "decimal.js";
 import { DateUtil } from "../../utils/DateUtil";
 
@@ -160,5 +162,31 @@ describe("Amortization", () => {
     });
     const schedule = amortization.calculateAmortizationPlan();
     expect(schedule.length).toBe(12);
+  });
+
+  it("should compute actual term including term extensions", () => {
+    const amortization = new Amortization({
+      loanAmount: Currency.of(1000),
+      annualInterestRate: new Decimal(0.05),
+      term: 12,
+      startDate: DateUtil.normalizeDate("2023-01-01"),
+      termExtensions: new TermExtensions([
+        new TermExtension({ termChange: 2 }),
+        new TermExtension({ termChange: -1 }),
+      ]),
+    });
+    expect(amortization.actualTerm).toBe(13);
+  });
+
+  it("should extend amortization schedule when term extensions are active", () => {
+    const amortization = new Amortization({
+      loanAmount: Currency.of(1000),
+      annualInterestRate: new Decimal(0.05),
+      term: 12,
+      startDate: DateUtil.normalizeDate("2023-01-01"),
+      termExtensions: new TermExtensions([new TermExtension({ termChange: 4 })]),
+    });
+    const schedule = amortization.calculateAmortizationPlan();
+    expect(schedule.length).toBe(16);
   });
 });

--- a/src/frontend/engine-ui/src/app/overrides/overrides.component.html
+++ b/src/frontend/engine-ui/src/app/overrides/overrides.component.html
@@ -326,6 +326,38 @@
           </div>
         </p-accordion-content>
       </p-accordion-panel>
+
+      <!-- Term Extensions -->
+      <p-accordion-panel value="termExtensions">
+        <p-accordion-header>
+          <div>
+            <p-badge
+              class="mr-4"
+              badgeSize="xlarge"
+              [severity]="lendPeak.amortization.termExtensions.length > 0 ? 'contrast' : 'secondary'"
+              [value]="lendPeak.amortization.termExtensions.length"
+            ></p-badge>
+            Term Extensions
+          </div>
+        </p-accordion-header>
+        <p-accordion-content>
+          <!-- Placeholder table -->
+          <p-table [value]="lendPeak.amortization.termExtensions.all">
+            <ng-template pTemplate="header">
+              <tr>
+                <th>Change</th>
+                <th>Date</th>
+              </tr>
+            </ng-template>
+            <ng-template pTemplate="body" let-row>
+              <tr>
+                <td>{{ row.termChange }}</td>
+                <td>{{ row.date.toString() }}</td>
+              </tr>
+            </ng-template>
+          </p-table>
+        </p-accordion-content>
+      </p-accordion-panel>
       <p-accordion-panel value="termCalendarOverride">
         <p-accordion-header>
           <div>

--- a/src/frontend/engine-ui/src/app/overrides/overrides.component.ts
+++ b/src/frontend/engine-ui/src/app/overrides/overrides.component.ts
@@ -36,6 +36,8 @@ import { PreBillDaysConfigurations } from 'lendpeak-engine/models/PreBillDaysCon
 import { BillDueDaysConfiguration } from 'lendpeak-engine/models/BillDueDaysConfiguration';
 import { BillDueDaysConfigurations } from 'lendpeak-engine/models/BillDueDaysConfigurations';
 import { TermPaymentAmounts } from 'lendpeak-engine/models/TermPaymentAmounts';
+import { TermExtension } from 'lendpeak-engine/models/TermExtension';
+import { TermExtensions } from 'lendpeak-engine/models/TermExtensions';
 import { RateSchedules } from 'lendpeak-engine/models/RateSchedules';
 import { LendPeak } from 'lendpeak-engine/models/LendPeak';
 import { TermInterestAmountOverrides } from 'lendpeak-engine/models/TermInterestAmountOverrides';
@@ -479,6 +481,10 @@ export class OverridesComponent implements OnInit {
       this.openPanels.push('termPaymentAmount');
     }
 
+    if (this.lendPeak.amortization?.termExtensions?.length > 0) {
+      this.openPanels.push('termExtensions');
+    }
+
     // Panel: Term Interest Override
     if (
       this.lendPeak.amortization.termInterestAmountOverride &&
@@ -809,6 +815,16 @@ export class OverridesComponent implements OnInit {
     this.onInputChange(true);
   }
 
+  addTermExtension() {
+    if (!this.lendPeak) {
+      return;
+    }
+    const exts = this.lendPeak.amortization.termExtensions;
+    exts.addExtension(new TermExtension({ termChange: 1 }));
+    this.lendPeak.amortization.termExtensions = exts;
+    this.onInputChange(true);
+  }
+
   refreshSortForTermCalendarOverride() {
     if (!this.lendPeak) {
       return;
@@ -1127,6 +1143,13 @@ export class OverridesComponent implements OnInit {
     if (!this.lendPeak) return;
     const cpd = this.lendPeak.amortization.changePaymentDates;
     ev.checked ? cpd.activateAll() : cpd.deactivateAll();
+    this.onInputChange(true);
+  }
+
+  toggleAllTermExtensions(ev: any): void {
+    if (!this.lendPeak) return;
+    const exts = this.lendPeak.amortization.termExtensions;
+    ev.checked ? exts.activateAll() : exts.deactivateAll();
     this.onInputChange(true);
   }
 


### PR DESCRIPTION
## Summary
- compute term extensions in amortization `actualTerm`
- use `actualTerm` when generating schedules and monthly payment
- extend tests to verify schedule length with term extensions

## Testing
- `npm test` in `src/engine`
- `npm test` in `src/mappers/cls-mapper` *(fails: jest not found)*