### PR TITLE
Ensure systemDate serialization keeps time

### DIFF
--- a/src/engine/models/DepositRecord.ts
+++ b/src/engine/models/DepositRecord.ts
@@ -693,7 +693,7 @@ export class DepositRecord {
       insertedDate: DateUtil.normalizeDate("${this.insertedDate.toString()}"),
       effectiveDate: DateUtil.normalizeDate("${this.effectiveDate.toString()}"),
       clearingDate: ${this.clearingDate ? `DateUtil.normalizeDate("${this.clearingDate.toString()}")` : "undefined"},
-      systemDate: DateUtil.normalizeDate("${this.systemDate.toString()}"),
+      systemDate: DateUtil.normalizeDateTime("${this.systemDate.toString()}"),
       paymentMethod: ${this.paymentMethod ? `"${this.paymentMethod}"` : "undefined"},
       depositor: ${this.depositor ? `"${this.depositor}"` : "undefined"},
       depositLocation: ${this.depositLocation ? `"${this.depositLocation}"` : "undefined"},

--- a/src/engine/tests/models/depositRecord.test.ts
+++ b/src/engine/tests/models/depositRecord.test.ts
@@ -1,6 +1,6 @@
 import { DepositRecord } from "../../models/DepositRecord";
 import { Currency } from "../../utils/Currency";
-import { LocalDate } from "@js-joda/core";
+import { LocalDate, LocalDateTime } from "@js-joda/core";
 import { DateUtil } from "../../utils/DateUtil";
 
 describe('DepositRecord.toCode', () => {
@@ -13,5 +13,18 @@ describe('DepositRecord.toCode', () => {
     const code = deposit.toCode();
     expect(code).toContain('insertedDate');
     expect(code).toContain(DateUtil.normalizeDate(deposit.insertedDate).toString());
+  });
+
+  it('serializes systemDate with time component', () => {
+    const systemDate = LocalDateTime.parse('2024-01-02T14:15:16');
+    const deposit = new DepositRecord({
+      amount: Currency.of(50),
+      currency: 'USD',
+      effectiveDate: LocalDate.parse('2024-01-01'),
+      systemDate: systemDate,
+    });
+
+    const code = deposit.toCode();
+    expect(code).toContain(`DateUtil.normalizeDateTime("${systemDate.toString()}")`);
   });
 });


### PR DESCRIPTION
## Summary
- keep time when serializing systemDate in `toCode`
- add regression test for systemDate with time

## Testing
- `npm test`