### PR TITLE
Fix LoanPro date parsing

### DIFF
--- a/src/engine/tests/utils/dateUtils.test.ts
+++ b/src/engine/tests/utils/dateUtils.test.ts
@@ -86,4 +86,46 @@ describe("DateUtil", () => {
       expect(() => DateUtil.normalizeDateTime("2023-1")).toThrow("Date string too short, expected format YYYY-MM-DD");
     });
   });
+
+  describe("parseLoanProDateToLocalDate", () => {
+    it("should correctly parse milliseconds timestamp", () => {
+      const input = "/Date(1698278400000)/"; // 2023-10-26 UTC
+      const result = DateUtil.parseLoanProDateToLocalDate(input);
+      expect(result.toString()).toBe("2023-10-26");
+    });
+
+    it("should correctly parse seconds timestamp", () => {
+      const input = "/Date(1698278400)/"; // 2023-10-26 UTC in seconds
+      const result = DateUtil.parseLoanProDateToLocalDate(input);
+      expect(result.toString()).toBe("2023-10-26");
+    });
+
+    it("should throw on invalid input", () => {
+      expect(() => DateUtil.parseLoanProDateToLocalDate("/Date(foo)/")).toThrow("Invalid LoanPro date format");
+    });
+  });
+
+  describe("parseLoanProDateToLocalDateTime", () => {
+    it("should correctly parse milliseconds timestamp", () => {
+      const input = "/Date(1698278400000)/"; // 2023-10-26T00:00:00Z
+      const result = DateUtil.parseLoanProDateToLocalDateTime(input);
+      expect(result.toString()).toBe("2023-10-26T00:00");
+    });
+
+    it("should correctly parse seconds timestamp", () => {
+      const input = "/Date(1698278400)/"; // 2023-10-26T00:00:00Z in seconds
+      const result = DateUtil.parseLoanProDateToLocalDateTime(input);
+      expect(result.toString()).toBe("2023-10-26T00:00");
+    });
+  });
+
+  describe("monthsBetween", () => {
+    it("should never return negative zero", () => {
+      const a = LocalDate.parse("2023-04-30");
+      const b = LocalDate.parse("2023-03-31");
+      const diff = DateUtil.monthsBetween(a, b);
+      expect(Object.is(diff, -0)).toBe(false);
+      expect(diff).toBe(0);
+    });
+  });
 });

--- a/src/engine/utils/DateUtil.ts
+++ b/src/engine/utils/DateUtil.ts
@@ -190,8 +190,15 @@ export class DateUtil {
    */
   static parseLoanProDateToLocalDate(dateString: string): LocalDate {
     try {
-      const timestamp = parseInt(dateString.replace("/Date(", "").replace(")/", ""), 10);
-      return LocalDate.ofInstant(Instant.ofEpochSecond(timestamp), ZoneOffset.UTC);
+      const raw = parseInt(
+        dateString.replace("/Date(", "").replace(")/", ""),
+        10,
+      );
+      if (isNaN(raw)) {
+        throw new Error("Invalid LoanPro date format");
+      }
+      const timestamp = raw < 1e12 ? raw * 1000 : raw;
+      return LocalDate.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC);
     } catch (e) {
       console.error("Error parsing LoanPro date", e);
       throw new Error("Invalid LoanPro date format");
@@ -207,8 +214,18 @@ export class DateUtil {
    * This method keeps date and time, but completely discards the timezone.
    */
   static parseLoanProDateToLocalDateTime(dateString: string): LocalDateTime {
-    const timestamp = parseInt(dateString.replace("/Date(", "").replace(")/", ""), 10);
-    return LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), ZoneOffset.UTC);
+    const raw = parseInt(
+      dateString.replace("/Date(", "").replace(")/", ""),
+      10,
+    );
+    if (isNaN(raw)) {
+      throw new Error("Invalid LoanPro date format");
+    }
+    const timestamp = raw < 1e12 ? raw * 1000 : raw;
+    return LocalDateTime.ofInstant(
+      Instant.ofEpochMilli(timestamp),
+      ZoneOffset.UTC,
+    );
   }
 
   static monthsBetween(date1: LocalDate, date2: LocalDate): number {
@@ -237,6 +254,8 @@ export class DateUtil {
     }
 
     // Apply the sign based on the original order
-    return sign * totalMonths;
+    const result = sign * totalMonths;
+    // Avoid returning negative zero
+    return result === 0 ? 0 : result;
   }
 }


### PR DESCRIPTION
## Summary
- handle LoanPro date strings as milliseconds or seconds
- avoid negative zero in monthsBetween()
- add tests for LoanPro date parsing and monthsBetween

## Testing
- `npm test`
