### PR TITLE
Fix Bill summary property and document change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Welcome to LendPeak, an open-source lending software designed to be the best in the world, focusing on stability, transparency, and simplicity. LendPeak provides a robust platform for lenders and borrowers, ensuring smooth and reliable operations with a modern tech stack.
 
+### Recent Changes
+
+- The `Bill.summary` API now exposes a correctly named `remainingPrincipal` property.
+
 ## **Project Overview**
 
 LendPeak is built using the following technologies:

--- a/src/engine/models/Bill.ts
+++ b/src/engine/models/Bill.ts
@@ -386,7 +386,7 @@ export class Bill {
       feesDue: this.feesDue,
       remainingTotal: this.remainingTotal,
       remainingFees: this.remainingFees,
-      remainintPrincipal: this.remainingPrincipal,
+      remainingPrincipal: this.remainingPrincipal,
       remainingInterest: this.remainingInterest,
       allocatedTotalSum: this.allocatedTotalSum,
       allocatedFeesSum: this.allocatedFeesSum,

--- a/src/engine/tests/models/billSummary.test.ts
+++ b/src/engine/tests/models/billSummary.test.ts
@@ -1,0 +1,12 @@
+import { DemoC1 } from "@models/LendPeak/DemoLoans/demo-c1";
+
+describe("Bill summary", () => {
+  it("should expose remainingPrincipal and not the misspelled property", () => {
+    const lendPeak = DemoC1.LendPeakObject();
+    lendPeak.calc();
+    const firstBill = lendPeak.bills.first;
+    const summary = firstBill.summary as any;
+    expect(summary.remainingPrincipal).toBeDefined();
+    expect(summary).not.toHaveProperty("remainintPrincipal");
+  });
+});


### PR DESCRIPTION
## Summary
- add note about Bill.summary rename in README
- built engine locally and verified no remaining uses of misspelled property

## Testing
- `npm run build:all` in `src/engine`
- `npm test` in `src/engine`
- `npm test -- --watch=false` in `src/frontend/engine-ui` *(fails: Chrome not installed)*