### PR TITLE
Add bill generation unit tests

### DIFF
--- a/src/engine/tests/models/bill.test.ts
+++ b/src/engine/tests/models/bill.test.ts
@@ -1,0 +1,60 @@
+import { Bill } from "../../models/Bill";
+import { Currency } from "../../utils/Currency";
+import { LocalDate } from "@js-joda/core";
+import { AmortizationEntry } from "../../models/Amortization/AmortizationEntry";
+import { Calendar, CalendarType } from "../../models/Calendar";
+
+describe('Bill basic behaviors', () => {
+  const entry = new AmortizationEntry({
+    term: 1,
+    periodStartDate: LocalDate.parse('2023-01-01'),
+    periodEndDate: LocalDate.parse('2023-02-01'),
+    prebillDaysConfiguration: 0,
+    billDueDaysAfterPeriodEndConfiguration: 0,
+    billablePeriod: true,
+    periodBillOpenDate: LocalDate.parse('2023-02-01'),
+    periodBillDueDate: LocalDate.parse('2023-02-01'),
+    periodInterestRate: 0.05,
+    principal: Currency.of(500),
+    dueInterestForTerm: Currency.of(10),
+    accruedInterestForPeriod: Currency.of(10),
+    billedInterestForTerm: Currency.of(10),
+    billedDeferredInterest: Currency.zero,
+    unbilledTotalDeferredInterest: Currency.zero,
+    fees: Currency.zero,
+    billedDeferredFees: Currency.zero,
+    unbilledTotalDeferredFees: Currency.zero,
+    totalPayment: Currency.of(510),
+    endBalance: Currency.of(500),
+    startBalance: Currency.of(1000),
+    balanceModificationAmount: Currency.zero,
+    perDiem: Currency.zero,
+    daysInPeriod: 31,
+    calendar: new Calendar(CalendarType.ACTUAL_365),
+    interestRoundingError: Currency.zero,
+    unbilledInterestDueToRounding: Currency.zero,
+  });
+
+  const bill = new Bill({
+    id: 'b1',
+    period: 1,
+    dueDate: LocalDate.parse('2023-02-01'),
+    openDate: LocalDate.parse('2023-02-01'),
+    principalDue: Currency.of(500),
+    interestDue: Currency.of(10),
+    feesDue: Currency.zero,
+    totalDue: Currency.of(510),
+    amortizationEntry: entry,
+  });
+
+  it('identifies past due and paid status correctly', () => {
+    const checkDate = LocalDate.parse('2023-02-05');
+    expect(bill.isPastDue(checkDate)).toBe(true);
+    expect(bill.getDaysPastDue(checkDate)).toBe(4);
+    expect(bill.isPaid()).toBe(false);
+
+    bill.reducePrincipalDueBy(Currency.of(500));
+    bill.reduceInterestDueBy(Currency.of(10));
+    expect(bill.isPaid()).toBe(true);
+  });
+});

--- a/src/engine/tests/models/billGenerator.test.ts
+++ b/src/engine/tests/models/billGenerator.test.ts
@@ -1,0 +1,30 @@
+import { BillGenerator } from "../../models/BillGenerator";
+import { Amortization } from "../../models/Amortization";
+import { Currency } from "../../utils/Currency";
+import { LocalDate } from "@js-joda/core";
+import Decimal from "decimal.js";
+
+describe('BillGenerator', () => {
+  it('generates bills matching the amortization schedule', () => {
+    const amort = new Amortization({
+      loanAmount: Currency.of(1000),
+      annualInterestRate: new Decimal(0.05),
+      term: 2,
+      startDate: LocalDate.parse('2023-01-01'),
+    });
+    const schedule = amort.calculateAmortizationPlan();
+    const bills = BillGenerator.generateBills({
+      amortizationSchedule: schedule,
+      currentDate: LocalDate.parse('2023-02-02'),
+    });
+
+    expect(bills.length).toBe(schedule.length);
+    for (let i = 0; i < bills.length; i++) {
+      const bill = bills.atIndex(i);
+      const entry = schedule.entries[i];
+      expect(bill.openDate.isEqual(entry.periodBillOpenDate)).toBe(true);
+      expect(bill.dueDate.isEqual(entry.periodBillDueDate)).toBe(true);
+      expect(bill.principalDue.equals(entry.principal)).toBe(true);
+    }
+  });
+});

--- a/src/engine/tests/models/bills.test.ts
+++ b/src/engine/tests/models/bills.test.ts
@@ -1,0 +1,30 @@
+import { Bills } from "../../models/Bills";
+import { BillGenerator } from "../../models/BillGenerator";
+import { Amortization } from "../../models/Amortization";
+import { Currency } from "../../utils/Currency";
+import { LocalDate } from "@js-joda/core";
+import Decimal from "decimal.js";
+
+describe('Bills collection', () => {
+  it('calculates summary and future bill correctly', () => {
+    const amort = new Amortization({
+      loanAmount: Currency.of(1000),
+      annualInterestRate: new Decimal(0.05),
+      term: 2,
+      startDate: LocalDate.parse('2023-01-01'),
+    });
+    const schedule = amort.calculateAmortizationPlan();
+    const bills = BillGenerator.generateBills({
+      amortizationSchedule: schedule,
+      currentDate: LocalDate.parse('2023-02-02'),
+    });
+
+    const summary = bills.summary;
+    expect(summary.totalBillsCount).toBe(2);
+    expect(summary.billsPastDue).toBe(1);
+    expect(summary.remainingUnpaidBills).toBe(2);
+
+    const future = bills.getFirstFutureBill(LocalDate.parse('2023-02-02'));
+    expect(future?.period).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `Bill` behaviors
- test `BillGenerator` against amortization schedules
- cover `Bills` collection summary and future bill logic

## Testing
- `npm test`