### PR TITLE
Fix TermExtension date normalization

### DIFF
--- a/src/engine/models/TermExtension.ts
+++ b/src/engine/models/TermExtension.ts
@@ -1,4 +1,5 @@
 import { LocalDate } from '@js-joda/core';
+import { DateUtil } from '../utils/DateUtil';
 
 export interface TermExtensionParams {
   quantity: number;
@@ -47,12 +48,12 @@ export class TermExtension {
     this.modified = true;
   }
 
-  get date() {
+  get date(): LocalDate {
     return this._date;
   }
   set date(v: LocalDate | Date | string) {
-    this._date = v instanceof LocalDate ? v : LocalDate.parse(v instanceof Date ? v.toISOString().slice(0, 10) : v);
-    this.jsDate = new Date(this._date.toString());
+    this._date = DateUtil.normalizeDate(v);
+    this.jsDate = DateUtil.normalizeDateToJsDate(this._date);
     this.modified = true;
   }
 
@@ -85,7 +86,7 @@ export class TermExtension {
 
   updateJsValues(): void {
     this.jsQuantity = this.quantity;
-    this.jsDate = new Date(this.date.toString());
+    this.jsDate = DateUtil.normalizeDateToJsDate(this.date);
     this.jsDescription = this.description;
     this.jsActive = this.active;
     this.jsId = this.id;

--- a/src/engine/tests/models/termExtension.test.ts
+++ b/src/engine/tests/models/termExtension.test.ts
@@ -38,6 +38,14 @@ describe('TermExtension', () => {
     expect(ext.jsActive).toBe(false);
     expect(ext.jsId).toBe('id1');
   });
+
+  it('should normalize jsDate to UTC midnight', () => {
+    const dateWithTz = new Date('2024-03-01T10:00:00-05:00');
+    const ext = new TermExtension({ quantity: 1, date: dateWithTz });
+    expect(ext.jsDate.toISOString()).toBe('2024-03-01T00:00:00.000Z');
+    ext.date = '2024-04-15';
+    expect(ext.jsDate.toISOString()).toBe('2024-04-15T00:00:00.000Z');
+  });
 });
 
 describe('TermExtensions', () => {

--- a/src/engine/utils/DateUtil.ts
+++ b/src/engine/utils/DateUtil.ts
@@ -152,18 +152,15 @@ export class DateUtil {
   // this helps in UI to display the same date in all timezones
   // and it returns regular javascript Date
   static normalizeDateToJsDate(date: LocalDate): Date {
-    // if (dayjs.isDayjs(date)) {
-    //   return new Date(date.year(), date.month(), date.date());
-    // } else {
     try {
-      const jsDate = new Date(date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+      const jsDate = new Date(
+        date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli(),
+      );
       return jsDate;
     } catch (e) {
       console.error("Error normalizing date to JS Date", e);
       throw new Error("Invalid date format");
     }
-
-    // }
   }
 
   static normalizeDateTimeToJsDate(date: LocalDateTime): Date {


### PR DESCRIPTION
## Summary
- normalize TermExtension date using DateUtil.normalizeDate
- update normalizeDateToJsDate to use UTC instead of system timezone

## Testing
- `npm test`